### PR TITLE
Load jitsi each time

### DIFF
--- a/box-ui/src/components/ts/FormJoinMeeting.tsx
+++ b/box-ui/src/components/ts/FormJoinMeeting.tsx
@@ -50,7 +50,6 @@ const FormJoinMeeting: FunctionComponent<InformationProps> = (props: Information
                                         <TextField
                                             fullWidth
                                             id='outlined-adornment-amount'
-                                            defaultValue='meeting.education'
                                             placeholder='meeting.education'
                                             value={domain}
                                             helperText={t('enterValidDomain')}


### PR DESCRIPTION
Fix small error in Join Form component: should not use both default value and value, which used to trigger error:
```
MuiFilledInputInput contains an input of type text with both value and defaultValue props. Input elements must be either controlled or uncontrolled (specify either the value prop, or the defaultValue prop, but not both). Decide between using a controlled or uncontrolled input element and remove one of these props. More info: https://reactjs.org/link/controlled-components
```

Reload the Jitsi Script API each time a room is joined, to prevent version error between two jitsi meet servers, and to handle error when trying to join a non-jitsi meet server 