### PR TITLE
Freeze version of react keyboard

### DIFF
--- a/box-ui/package.json
+++ b/box-ui/package.json
@@ -28,7 +28,7 @@
     "react-qr-reader": "^2.2.1",
     "react-router-dom": "^6.0.1",
     "react-scripts": "4.0.3",
-    "react-simple-keyboard": "^3.3.26",
+    "react-simple-keyboard": "3.4.4",
     "reactjs-popup": "^2.0.5",
     "typescript": "^4.1.2",
     "uuid": "^8.3.2",


### PR DESCRIPTION
Freeze package version:
Going from 3.4.4 to 3.4.10 caused a type error in typescript:
![image](https://user-images.githubusercontent.com/66471981/145594442-1a56cd11-063c-4717-abde-3d6a93789157.png)
