### PR TITLE
✨ Makes sure the screen flashes when a hand is raised and automatically turns off

### DIFF
--- a/box-ui/src/components/css/BoxMeeting.css
+++ b/box-ui/src/components/css/BoxMeeting.css
@@ -28,5 +28,4 @@
 }
 .JitsiComponent {
     flex-grow: 3;
-    background-color: chartreuse;
 }

--- a/box-ui/src/components/css/BoxMeeting.css
+++ b/box-ui/src/components/css/BoxMeeting.css
@@ -28,4 +28,5 @@
 }
 .JitsiComponent {
     flex-grow: 3;
+    background-color: chartreuse;
 }

--- a/box-ui/src/components/css/JitsiComponent.css
+++ b/box-ui/src/components/css/JitsiComponent.css
@@ -13,3 +13,14 @@
 
     background: #dd3849;
 }
+.overlay {
+    opacity: 0.8;
+    background-color: 'yellow';
+    position: fixed;
+    width: 100%;
+    height: 100%;
+    top: 0px;
+    left: 0px;
+    z-index: 1000;
+    pointer-events: none;
+}

--- a/box-ui/src/components/tests/JitsiComponent.test.tsx
+++ b/box-ui/src/components/tests/JitsiComponent.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import JitsiFrame from '../ts/JitsiFrame';
 
 test('renders learn react link', () => {
-    render(<JitsiFrame information={{ domain: '', roomName: '' }} showYellowbg={false} options={{}} />);
+    render(<JitsiFrame information={{ domain: '', roomName: '' }} isBox={false} options={{}} />);
     const linkElement = screen.getByText(/learn react/i);
     expect(linkElement).toBeInTheDocument();
 });

--- a/box-ui/src/components/tests/JitsiComponent.test.tsx
+++ b/box-ui/src/components/tests/JitsiComponent.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import JitsiFrame from '../ts/JitsiFrame';
 
 test('renders learn react link', () => {
-    render(<JitsiFrame information={{ domain: '', roomName: '' }} options={{}} />);
+    render(<JitsiFrame information={{ domain: '', roomName: '' }} showYellowbg={false} options={{}} />);
     const linkElement = screen.getByText(/learn react/i);
     expect(linkElement).toBeInTheDocument();
 });

--- a/box-ui/src/components/ts/Box/BoxMeeting.tsx
+++ b/box-ui/src/components/ts/Box/BoxMeeting.tsx
@@ -48,7 +48,7 @@ const BoxMeeting: FunctionComponent = () => {
                 <div className='JitsiComponent'>
                     <JitsiFrame
                         information={information}
-                        showYellowbg={true}
+                        isBox={true}
                         options={meetingOptions}
                         configure={(api) => {
                             api.addListener('videoConferenceLeft', () => {

--- a/box-ui/src/components/ts/Box/BoxMeeting.tsx
+++ b/box-ui/src/components/ts/Box/BoxMeeting.tsx
@@ -41,7 +41,12 @@ const BoxMeeting: FunctionComponent = () => {
     return (
         <div className='BoxMeeting'>
             <PopupComponent information={information} setInformation={setInformation} />
-            <div className='CreateMeetingContainer'>
+            <div
+                className='CreateMeetingContainer'
+                style={{
+                    backgroundColor: 'yellow',
+                }}
+            >
                 <div className='JitsiComponent'>
                     <JitsiFrame
                         information={information}

--- a/box-ui/src/components/ts/Box/BoxMeeting.tsx
+++ b/box-ui/src/components/ts/Box/BoxMeeting.tsx
@@ -41,12 +41,7 @@ const BoxMeeting: FunctionComponent = () => {
     return (
         <div className='BoxMeeting'>
             <PopupComponent information={information} setInformation={setInformation} />
-            <div
-                className='CreateMeetingContainer'
-                style={{
-                    backgroundColor: 'yellow',
-                }}
-            >
+            <div className='CreateMeetingContainer'>
                 <div className='JitsiComponent'>
                     <JitsiFrame
                         information={information}

--- a/box-ui/src/components/ts/Box/BoxMeeting.tsx
+++ b/box-ui/src/components/ts/Box/BoxMeeting.tsx
@@ -40,58 +40,15 @@ const BoxMeeting: FunctionComponent = () => {
         }),
         [],
     );
-    const [raised, setRaised] = useState(false);
-    const [counter, setCounter] = useState(0);
-    const TimeOutRef = useRef<NodeJS.Timeout>();
-
-    function lowerHand() {
-        setRaised(false);
-        setCounter(0);
-    }
-
-    const updateCounter = useCallback((timeRaised: number) => {
-        if (timeRaised > 0) {
-            setCounter((counter) => counter + 1);
-        }
-        if (timeRaised == 0) {
-            setCounter((counter) => Math.max(0, counter - 1));
-        }
-    }, []);
-
-    function switchHand() {
-        let stop = false;
-        if (counter > 0) {
-            stop = true;
-        }
-        if (stop) {
-            setRaised(true);
-        } else {
-            setRaised(false);
-        }
-    }
-    useEffect(() => {
-        const id = setTimeout(lowerHand, 10000);
-        if (TimeOutRef.current) {
-            clearTimeout(TimeOutRef.current);
-        }
-        TimeOutRef.current = id;
-        switchHand();
-    }, [counter]);
 
     return (
         <div className='BoxMeeting'>
             <PopupComponent information={information} setInformation={setInformation} />
             <div className='CreateMeetingContainer'>
                 <div className='JitsiComponent'>
-                    <div
-                        className='overlay'
-                        style={{
-                            backgroundColor: 'yellow',
-                            opacity: raised ? '0.5' : '0',
-                        }}
-                    />
                     <JitsiFrame
                         information={information}
+                        showYellowbg={true}
                         options={meetingOptions}
                         configure={(api) => {
                             api.addListener('videoConferenceLeft', () => {
@@ -103,10 +60,6 @@ const BoxMeeting: FunctionComponent = () => {
                                         domain: information.domain,
                                     },
                                 });
-                            });
-                            api.addListener('raiseHandUpdated', (res) => {
-                                const timeRaised = res.handRaised;
-                                updateCounter(timeRaised);
                             });
                         }}
                         onError={() => {

--- a/box-ui/src/components/ts/Box/BoxMeeting.tsx
+++ b/box-ui/src/components/ts/Box/BoxMeeting.tsx
@@ -1,4 +1,4 @@
-import React, { useState, FunctionComponent } from 'react';
+import React, { useRef, useState, useEffect, useMemo, useCallback, FunctionComponent } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import '../../css/BoxMeeting.css';
 import PopupComponent from '../PopupComponent';
@@ -12,37 +12,84 @@ const BoxMeeting: FunctionComponent = () => {
         roomName: state && state.roomName ? state.roomName : 'dty',
         domain: state && state.domain ? state.domain : 'meeting.education',
     });
-    const meetingOptions = {
-        userInfo: {
-            email: '',
-            displayName: 'Jitsi-Box',
-        },
-        configOverwrite: {
-            toolbarButtons: [
-                'microphone',
-                'camera',
-                'videoquality',
-                'fodeviceselection',
-                'raisehand',
-                'tileview',
-                'hangup',
-            ],
-            toolbarConfig: {
-                alwaysVisible: true,
+    const meetingOptions = useMemo(
+        () => ({
+            userInfo: {
+                email: '',
+                displayName: 'Jitsi-Box',
             },
-            prejoinConfig: {
-                enabled: false,
+            configOverwrite: {
+                toolbarButtons: [
+                    'microphone',
+                    'camera',
+                    'videoquality',
+                    'fodeviceselection',
+                    'raisehand',
+                    'tileview',
+                    'hangup',
+                ],
+                toolbarConfig: {
+                    alwaysVisible: true,
+                },
+                prejoinConfig: {
+                    enabled: false,
+                },
+                startWithVideoMuted: false,
+                startWithAudioMuted: true,
             },
-            startWithVideoMuted: false,
-            startWithAudioMuted: true,
-        },
-    };
+        }),
+        [],
+    );
+    const [raised, setRaised] = useState(false);
+    const [counter, setCounter] = useState(0);
+    const TimeOutRef = useRef<NodeJS.Timeout>();
+
+    function lowerHand() {
+        setRaised(false);
+        setCounter(0);
+    }
+
+    const updateCounter = useCallback((timeRaised: number) => {
+        if (timeRaised > 0) {
+            setCounter((counter) => counter + 1);
+        }
+        if (timeRaised == 0) {
+            setCounter((counter) => Math.max(0, counter - 1));
+        }
+    }, []);
+
+    function switchHand() {
+        let stop = false;
+        if (counter > 0) {
+            stop = true;
+        }
+        if (stop) {
+            setRaised(true);
+        } else {
+            setRaised(false);
+        }
+    }
+    useEffect(() => {
+        const id = setTimeout(lowerHand, 10000);
+        if (TimeOutRef.current) {
+            clearTimeout(TimeOutRef.current);
+        }
+        TimeOutRef.current = id;
+        switchHand();
+    }, [counter]);
 
     return (
         <div className='BoxMeeting'>
             <PopupComponent information={information} setInformation={setInformation} />
             <div className='CreateMeetingContainer'>
                 <div className='JitsiComponent'>
+                    <div
+                        className='overlay'
+                        style={{
+                            backgroundColor: 'yellow',
+                            opacity: raised ? '0.5' : '0',
+                        }}
+                    />
                     <JitsiFrame
                         information={information}
                         options={meetingOptions}
@@ -56,6 +103,10 @@ const BoxMeeting: FunctionComponent = () => {
                                         domain: information.domain,
                                     },
                                 });
+                            });
+                            api.addListener('raiseHandUpdated', (res) => {
+                                const timeRaised = res.handRaised;
+                                updateCounter(timeRaised);
                             });
                         }}
                         onError={() => {

--- a/box-ui/src/components/ts/JitsiFrame.tsx
+++ b/box-ui/src/components/ts/JitsiFrame.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, FunctionComponent } from 'react';
+import React, { useRef, useState, useEffect, FunctionComponent } from 'react';
 import '../css/JitsiComponent.css';
 import { JitsiFrameProps } from '../../utils/Props';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -69,7 +69,7 @@ const JitsiFrame: FunctionComponent<JitsiFrameProps> = (props: JitsiFrameProps) 
 
     const [raised, setRaised] = useState(false);
     const [counter, setCounter] = useState(0);
-    const [idTo, setidTo] = useState<any>();
+    const TimeOutRef = useRef<NodeJS.Timeout>();
 
     function lowerHand() {
         setRaised(false);
@@ -98,8 +98,10 @@ const JitsiFrame: FunctionComponent<JitsiFrameProps> = (props: JitsiFrameProps) 
     }
     useEffect(() => {
         const id = setTimeout(lowerHand, 10000);
-        clearTimeout(idTo);
-        setidTo(id);
+        if (TimeOutRef.current) {
+            clearTimeout(TimeOutRef.current);
+        }
+        TimeOutRef.current = id;
         switchHand();
     }, [counter]);
 

--- a/box-ui/src/components/ts/JitsiFrame.tsx
+++ b/box-ui/src/components/ts/JitsiFrame.tsx
@@ -67,7 +67,7 @@ const JitsiFrame: FunctionComponent<JitsiFrameProps> = (props: JitsiFrameProps) 
         };
     }, [props.information, props.options, props.configure, props.onError]);
 
-    const ShowYellowbg = props.showYellowbg;
+    const ShowYellowbg = props.isBox;
     const [raised, setRaised] = useState(false);
     const [counter, setCounter] = useState(0);
     const TimeOutRef = useRef<NodeJS.Timeout>();
@@ -87,15 +87,7 @@ const JitsiFrame: FunctionComponent<JitsiFrameProps> = (props: JitsiFrameProps) 
     };
 
     function switchHand() {
-        let stop = false;
-        if (counter > 0) {
-            stop = true;
-        }
-        if (stop) {
-            setRaised(true);
-        } else {
-            setRaised(false);
-        }
+        setRaised(counter > 0);
     }
     useEffect(() => {
         const id = setTimeout(lowerHand, 10000);

--- a/box-ui/src/components/ts/JitsiFrame.tsx
+++ b/box-ui/src/components/ts/JitsiFrame.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect, FunctionComponent } from 'react';
+import React, { useEffect, FunctionComponent } from 'react';
 import '../css/JitsiComponent.css';
 import { JitsiFrameProps } from '../../utils/Props';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -51,10 +51,6 @@ const JitsiFrame: FunctionComponent<JitsiFrameProps> = (props: JitsiFrameProps) 
                     api.dispose();
                 });
                 props.configure?.(api);
-                api.addListener('raiseHandUpdated', (res) => {
-                    const timeRaised = res.handRaised;
-                    updateCounter(timeRaised);
-                });
             })
             .catch(() => {
                 alert('Error loading Jitsi Meet API');
@@ -67,54 +63,9 @@ const JitsiFrame: FunctionComponent<JitsiFrameProps> = (props: JitsiFrameProps) 
         };
     }, [props.information, props.options, props.configure, props.onError]);
 
-    const [raised, setRaised] = useState(false);
-    const [counter, setCounter] = useState(0);
-    const TimeOutRef = useRef<NodeJS.Timeout>();
-
-    function lowerHand() {
-        setRaised(false);
-        setCounter(0);
-    }
-
-    function updateCounter(timeRaised: number) {
-        if (timeRaised > 0) {
-            setCounter((counter) => counter + 1);
-        }
-        if (timeRaised == 0) {
-            setCounter((counter) => Math.max(0, counter - 1));
-        }
-    }
-
-    function switchHand() {
-        let stop = false;
-        if (counter > 0) {
-            stop = true;
-        }
-        if (stop) {
-            setRaised(true);
-        } else {
-            setRaised(false);
-        }
-    }
-    useEffect(() => {
-        const id = setTimeout(lowerHand, 10000);
-        if (TimeOutRef.current) {
-            clearTimeout(TimeOutRef.current);
-        }
-        TimeOutRef.current = id;
-        switchHand();
-    }, [counter]);
-
     return (
         <div style={{ height: '100%' }}>
             <div id='jitsi-container' className='jitsiContainer' />
-            <div
-                className='overlay'
-                style={{
-                    backgroundColor: 'yellow',
-                    opacity: raised ? '0.5' : '0',
-                }}
-            />
         </div>
     );
 };

--- a/box-ui/src/utils/Props/index.d.ts
+++ b/box-ui/src/utils/Props/index.d.ts
@@ -37,7 +37,7 @@ interface InformationProps {
 
 export type JitsiFrameProps = {
     information: Information;
-    showYellowbg : boolean;
+    isBox : boolean;
     options: ConstructorParameters<typeof JitsiMeetExternalAPI>[1];
     configure?: (api: JitsiMeetExternalAPI) => void;
     onError?: () => void;

--- a/box-ui/src/utils/Props/index.d.ts
+++ b/box-ui/src/utils/Props/index.d.ts
@@ -37,6 +37,7 @@ interface InformationProps {
 
 export type JitsiFrameProps = {
     information: Information;
+    showYellowbg : boolean;
     options: ConstructorParameters<typeof JitsiMeetExternalAPI>[1];
     configure?: (api: JitsiMeetExternalAPI) => void;
     onError?: () => void;


### PR DESCRIPTION
✨(React) Makes sure the screen flashes when a hand is raised and automatically turns off

The feature enables a listener that waits for a "raised hand" event and triggers the flashing of the screen for 10 seconds then turns it off without lowering the hands to keep a history of the raised hands. It also restarts the 10 seconds counter every time a hand is raised in order not to have interference.

No breaking changes 