### PR TITLE
🐛 (i18next) Fix automatic detection of language

### DIFF
--- a/box-ui/src/i18n.ts
+++ b/box-ui/src/i18n.ts
@@ -16,10 +16,3 @@ i18n.use(initReactI18next).use(LanguageDetector).init({
     defaultNS: 'common',
     fallbackLng: 'en',
 });
-const boxStorage = window.localStorage;
-if (boxStorage.getItem('language') != null) {
-    const language = boxStorage.getItem('language') as string;
-    i18n.changeLanguage(language);
-} else {
-    i18n.changeLanguage('en');
-}


### PR DESCRIPTION
Remove the call to custom 'language' value in local storage as it is
redundant with i18n saved value and
stopped i18n from detecting user's language.