### PR TITLE
🔥(jitsi-box:studentMeeting) delete unused superRes option for lack of computational power

### DIFF
--- a/box-ui/src/components/ts/Student/StudentMeeting.tsx
+++ b/box-ui/src/components/ts/Student/StudentMeeting.tsx
@@ -17,7 +17,7 @@ import { v1 as uuidv1 } from 'uuid';
 const StudentMeeting: FunctionComponent = () => {
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const open = Boolean(anchorEl);
-    const processes = ['Color', 'B&W', 'Contrast', 'original', 'SuperRes'];
+    const processes = ['Color', 'B&W', 'Contrast', 'original'];
     const [displayFocus, setDisplayFocus] = useState(false);
     const handleClick = (event: React.MouseEvent<HTMLElement>) => {
         setAnchorEl(event.currentTarget);


### PR DESCRIPTION

delete the superRes option filter from the front, could be readded in the future if sufficient computational power is available, works well especially with low resolution cameras