### PR TITLE
🐛(StudentMeeting) fix whiteboard layout

### DIFF
--- a/box-ui/src/components/css/StudentMeeting.css
+++ b/box-ui/src/components/css/StudentMeeting.css
@@ -78,26 +78,34 @@ button:hover {
     display: flex;
     justify-content: center;
     align-items: center;
+    position: relative;
+    margin: 5px;
 }
 
 .circularProgress {
     position: absolute;
     top: 50%;
-    left: 48%;
+    left: 50%;
     color: blue;
     z-index: 3;
+    transform: translate(-50%, -50%);
 }
 
-.container_loading {
+.containerLoading {
     position: relative;
+    max-width: 100%;
+    max-height: 100%;
+    min-width: 0px;
+    min-height: 0px;
+    margin: 5px;
 }
 
 .containerImgStudent {
     width: 100%;
-    height: 100%;
+    max-height: 48vh;
     background-color: rgb(15, 15, 15);
     display: grid;
-    grid-template-columns: 1fr 2fr 1fr;
+    grid-template-columns: 1fr 10fr 1fr;
     grid-template-areas: ' . viewer buttons';
 }
 
@@ -106,15 +114,45 @@ button:hover {
     grid-template-areas: 'viewer buttons';
 }
 
+.containerImgStudent.maximize {
+    max-height: 100vh;
+}
+
 .ImageViewer {
     grid-area: viewer;
     place-self: center;
-    place-self: center;
     display: flex;
     flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    max-width: 100%;
+    max-height: 100%;
+    min-height: 0px;
+    min-width: 0px;
+    padding: 5px;
 }
 
-.jitsiFloating {
+#croppedImage, #originalImage {
+    max-width: 100%;
+    max-height: 45vh;
+    min-width: 0px;
+    min-height: 0px;
+    object-fit: contain;
+}
+
+#originalImage {
+    border: 2px solid #184777;
+}
+
+.containerImgStudent.maximize #croppedImage, .containerImgStudent.maximize #originalImage {
+    max-height: 100vh;
+}
+
+.containerImgStudent.maximize {
+    height: 100vh;
+}
+
+.jitsiFrame.floating {
     padding: 20px;
     background-color: rgb(25, 25, 25);
 }

--- a/box-ui/src/components/ts/ImageViewer.tsx
+++ b/box-ui/src/components/ts/ImageViewer.tsx
@@ -8,41 +8,51 @@ const ImageViewer: FunctionComponent<ViewerProps> = (props: ViewerProps) => {
     return (
         <div className='ImageViewer'>
             {props.img2 && props.selectWindow && (
-                <div className='sectionClick'>
-                    <ClickableSVG
-                        height={props.img2[1]}
-                        width={props.img2[2]}
-                        onClick={props.onclick}
-                        style={{
-                            backgroundImage: "url('" + props.img2[0] + "')",
-                            backgroundRepeat: 'no-repeat',
-                            backgroundSize: 'contain',
-                            border: '1px solid blue',
-                        }}
-                    >
-                        {props.addOn}
+                <div className='sectionClick' onClick={props.onclick}>
+                    <img id='originalImage' src={props.img2} />
+                    <ClickableSVG>
+                        {props.coords?.map((coord) => {
+                            return (
+                                <circle
+                                    key={Math.round(coord[0] + coord[1] * 100)}
+                                    cx={Math.round(
+                                        coord[0] *
+                                            (document.getElementById('originalImage')?.getBoundingClientRect().width ??
+                                                0),
+                                    )}
+                                    cy={Math.round(
+                                        coord[1] *
+                                            (document.getElementById('originalImage')?.getBoundingClientRect().height ??
+                                                0),
+                                    )}
+                                    r='6'
+                                    stroke='white'
+                                    strokeWidth='2'
+                                    fill='blue'
+                                />
+                            );
+                        })}
                     </ClickableSVG>
                 </div>
             )}
-            <div className='container_loading'>
-                <ClickableSVG
-                    height={props.img1[1]}
-                    width={props.img1[2]}
-                    style={{
-                        backgroundImage: "url('" + props.img1[0] + "')",
-                        backgroundRepeat: 'no-repeat',
-                        backgroundSize: 'contain',
-                    }}
-                ></ClickableSVG>
-                {props.loading && <CircularProgress className='circularProgress' />}
+            <div className='containerLoading'>
+                <img id='croppedImage' src={props.img1} />
+                {props.loading && (
+                    <div className='circularProgress'>
+                        <CircularProgress />
+                    </div>
+                )}
             </div>
         </div>
     );
 };
 const ClickableSVG = styled.svg`
-    background-repeat: no-repeat;
-    background-size: contain;
-    background-color: black;
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    z-index: 2;
     & * {
         /* Block your circles from triggering 'add circle' */
         pointer-events: none;

--- a/box-ui/src/components/ts/ImageViewer.tsx
+++ b/box-ui/src/components/ts/ImageViewer.tsx
@@ -9,7 +9,7 @@ const ImageViewer: FunctionComponent<ViewerProps> = (props: ViewerProps) => {
         <div className='ImageViewer'>
             {props.img2 && props.selectWindow && (
                 <div className='sectionClick' onClick={props.onclick}>
-                    <img id='originalImage' src={props.img2} />
+                    <img draggable='false' id='originalImage' src={props.img2} />
                     <ClickableSVG>
                         {props.coords?.map((coord) => {
                             return (
@@ -36,7 +36,7 @@ const ImageViewer: FunctionComponent<ViewerProps> = (props: ViewerProps) => {
                 </div>
             )}
             <div className='containerLoading'>
-                <img id='croppedImage' src={props.img1} />
+                <img draggable='false' id='croppedImage' src={props.img1} />
                 {props.loading && (
                     <div className='circularProgress'>
                         <CircularProgress />

--- a/box-ui/src/utils/Props/index.d.ts
+++ b/box-ui/src/utils/Props/index.d.ts
@@ -71,10 +71,10 @@ export type FocusModeProps = {
 };
 
 export type ViewerProps = {
-    img1: [string, string, string];
-    img2?: [string, string, string];
+    img1: string;
+    img2?: string;
     onclick?: (event: React.MouseEvent) => void;
-    addOn?: React.SVGProps<SVGCircleElement>[];
+    coords?: [number, number][];
     selectWindow: boolean;
     loading: boolean;
 };


### PR DESCRIPTION
The way the whiteboard is displayed (using vh for the dimensions and
calculating width and haight based on aspect ratio) leads to several
problem. First the image resizes in strange way when the window is
resize but mostly the buttons are overflowing when displaying two images
duing crops.

I had to change the way images are displayed allowing them
to expand up to the container limit. I also refactored some of the state
to handle the circles creation in the ImageViewer as it was making it
more understandable and was removing one state.